### PR TITLE
fix header from overwrapping titles

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -278,7 +278,7 @@ epubmaker:
 texstyle: reviewmacro
 #
 # LaTeX用のdocumentclassを指定する
-# texdocumentclass: ["jsbook", "uplatex,oneside"]
+texdocumentclass: ["jsbook", "11pt,uplatex,twoside"]
 #
 # LaTeX用のコマンドを指定する
 # texcommand: "uplatex"

--- a/sty/reviewmacro.sty
+++ b/sty/reviewmacro.sty
@@ -1,9 +1,10 @@
 %% from review-pdfmaker
 \usepackage{fancyhdr}
 \pagestyle{fancy}
-\lhead{\gtfamily\sffamily\bfseries\upshape \leftmark}
-\chead{}
-\rhead{\gtfamily\sffamily\bfseries\upshape \rightmark}
+\fancyhf{}
+\fancyhead[RO]{\gtfamily\sffamily\bfseries\upshape \rightmark}
+\fancyhead[LE]{\gtfamily\sffamily\bfseries\upshape \leftmark}
+\fancyfoot[LE,RO]{\thepage}
 \renewcommand{\sectionmark}[1]{\markright{\thesection~#1}{}}
 \renewcommand{\chaptermark}[1]{\markboth{\prechaptername\ \thechapter\ \postchaptername~#1}{}}
 \renewcommand{\headfont}{\gtfamily\sffamily\bfseries}
@@ -11,9 +12,10 @@
 \fancypagestyle{plainhead}{%
 \fancyhead{}
 \fancyfoot{} % clear all header and footer fields
-\fancyfoot[CE,CO]{\thepage}
+\fancyfoot[LE,RO]{\thepage}
 \renewcommand{\headrulewidth}{0pt}
 \renewcommand{\footrulewidth}{0pt}}
+\setlength{\headheight}{15mm}
 
 %% using Helvetica as sans-serif
 \renewcommand{\sfdefault}{phv}


### PR DESCRIPTION
見開き用の設定にして、偶数ページに章タイトル、奇数ページに節タイトルがくるようにしてみました。
フッタのノンブルも左右に表示するようにしています。
また、後ろの方の章で節タイトルが2行になってしまうものがあるため、ヘッダの高さ`\headheight `を調整しています。